### PR TITLE
Initialize GolfTracker skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "GolfTracker",
+    platforms: [
+        .iOS(.v15)
+    ],
+    targets: [
+        .executableTarget(
+            name: "GolfTracker",
+            path: "Sources/GolfTracker"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # GolfTracker
+
+An experimental iOS app that records golf shots and predicts ball flight.
+
+## Features
+
+- Connects to the Foresight GCQuad launch monitor (placeholder implementation).
+- Records the GPS location of each shot using CoreLocation.
+- Retrieves real-time wind information (placeholder implementation).
+- Predicts the landing position of the ball.
+- Allows video recording of the swing using AVFoundation.
+
+This project is structured as a Swift Package so it can be developed in VS Code.
+Open the folder in VS Code with the Swift extension installed. Xcode can also be
+used for running on device or simulator.
+
+## Building
+
+```bash
+swift build
+```
+
+Running the package on macOS or iOS will launch the simple command-line app that
+performs a single shot capture cycle.

--- a/Sources/GolfTracker/BallTracker.swift
+++ b/Sources/GolfTracker/BallTracker.swift
@@ -1,0 +1,13 @@
+import CoreLocation
+
+/// Responsible for predicting where the ball will land using shot and weather data.
+final class BallTracker {
+    func predictLanding(shot: ShotData, from location: CLLocationCoordinate2D, wind: WindData) -> CLLocationCoordinate2D {
+        // TODO: Replace with sophisticated physics model.
+        // This stub simply advances the latitude by a rough distance calculation.
+        let distanceMeters = shot.ballSpeed * cos(shot.launchAngle * .pi/180) * 0.5
+        let earthRadius = 6378137.0
+        let deltaLat = distanceMeters / earthRadius * 180 / .pi
+        return CLLocationCoordinate2D(latitude: location.latitude + deltaLat, longitude: location.longitude)
+    }
+}

--- a/Sources/GolfTracker/GCQuadManager.swift
+++ b/Sources/GolfTracker/GCQuadManager.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct ShotData {
+    let launchAngle: Double
+    let spinRate: Double
+    let ballSpeed: Double
+}
+
+/// Placeholder class representing a connection to the Foresight GCQuad device.
+/// In a real implementation this would handle network or Bluetooth communication
+/// with the device and parse the shot data stream it provides.
+final class GCQuadManager {
+    func readShotData() async -> ShotData? {
+        // TODO: Replace with real GCQuad integration.
+        // This stub simply returns some fake data.
+        return ShotData(launchAngle: 12.0, spinRate: 2500, ballSpeed: 165)
+    }
+}

--- a/Sources/GolfTracker/LocationManager.swift
+++ b/Sources/GolfTracker/LocationManager.swift
@@ -1,0 +1,30 @@
+import CoreLocation
+
+/// Provides the current GPS location using CoreLocation.
+final class LocationManager: NSObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocationCoordinate2D?, Never>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+    }
+
+    func currentLocation() async -> CLLocationCoordinate2D? {
+        manager.requestWhenInUseAuthorization()
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            manager.requestLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        continuation?.resume(returning: locations.first?.coordinate)
+        continuation = nil
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        continuation?.resume(returning: nil)
+        continuation = nil
+    }
+}

--- a/Sources/GolfTracker/VideoRecorder.swift
+++ b/Sources/GolfTracker/VideoRecorder.swift
@@ -1,0 +1,16 @@
+import AVFoundation
+
+/// Simple video recorder placeholder using AVFoundation.
+final class VideoRecorder {
+    private var session: AVCaptureSession?
+
+    func startRecording() async {
+        // TODO: Configure camera and start recording.
+        session = AVCaptureSession()
+        session?.startRunning()
+    }
+
+    func stopRecording() async {
+        session?.stopRunning()
+    }
+}

--- a/Sources/GolfTracker/WeatherService.swift
+++ b/Sources/GolfTracker/WeatherService.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreLocation
+
+struct WindData {
+    let speed: Double // meters per second
+    let direction: Double // degrees from north
+}
+
+/// Retrieves weather information to account for wind effect on the ball.
+final class WeatherService {
+    func currentWind(at location: CLLocationCoordinate2D) async -> WindData {
+        // TODO: Replace with real weather API (e.g. WeatherKit or OpenWeather).
+        // For now return a dummy calm wind.
+        return WindData(speed: 0, direction: 0)
+    }
+}

--- a/Sources/GolfTracker/main.swift
+++ b/Sources/GolfTracker/main.swift
@@ -1,0 +1,30 @@
+import Foundation
+import CoreLocation
+
+@main
+struct GolfTrackerApp {
+    static func main() async {
+        let gcQuad = GCQuadManager()
+        let locationManager = LocationManager()
+        let weather = WeatherService()
+        let tracker = BallTracker()
+        let videoRecorder = VideoRecorder()
+
+        await videoRecorder.startRecording()
+        guard let shotLocation = await locationManager.currentLocation() else {
+            print("Failed to get location")
+            return
+        }
+
+        guard let shotData = await gcQuad.readShotData() else {
+            print("No shot data available")
+            return
+        }
+
+        let wind = await weather.currentWind(at: shotLocation)
+        let predicted = tracker.predictLanding(shot: shotData, from: shotLocation, wind: wind)
+        print("Predicted landing at \(predicted.latitude), \(predicted.longitude)")
+
+        await videoRecorder.stopRecording()
+    }
+}


### PR DESCRIPTION
## Summary
- add Swift Package skeleton for iOS app
- implement placeholder managers for GCQuad, location, weather, ball physics and video
- provide simple main entry point
- document building in README

## Testing
- `swift build` *(fails: no such module 'CoreLocation')*

------
https://chatgpt.com/codex/tasks/task_e_687121dcd8048322972ab66a7449afc3