### PR TITLE
Fix concurrency data race warnings

### DIFF
--- a/Sources/GolfTracker/LocationManager.swift
+++ b/Sources/GolfTracker/LocationManager.swift
@@ -1,5 +1,6 @@
 import CoreLocation
 
+@MainActor
 /// Provides the current GPS location using CoreLocation.
 final class LocationManager: NSObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()

--- a/Sources/GolfTracker/VideoRecorder.swift
+++ b/Sources/GolfTracker/VideoRecorder.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 
+@MainActor
 /// Records video of the golf swing using ``AVFoundation``. This basic
 /// implementation configures the default camera and writes a single movie file
 /// to the temporary directory.


### PR DESCRIPTION
## Summary
- ensure `LocationManager` runs on the main actor
- ensure `VideoRecorder` runs on the main actor

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68719aac90e08322add2782b9e3b849e