### PR TITLE
Fix delegate isolation errors

### DIFF
--- a/Sources/GolfTracker/LocationManager.swift
+++ b/Sources/GolfTracker/LocationManager.swift
@@ -19,13 +19,17 @@ final class LocationManager: NSObject, CLLocationManagerDelegate {
         }
     }
 
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        continuation?.resume(returning: locations.first?.coordinate)
-        continuation = nil
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        Task { @MainActor in
+            self.continuation?.resume(returning: locations.first?.coordinate)
+            self.continuation = nil
+        }
     }
 
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        continuation?.resume(returning: nil)
-        continuation = nil
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.continuation?.resume(returning: nil)
+            self.continuation = nil
+        }
     }
 }

--- a/Sources/GolfTracker/VideoRecorder.swift
+++ b/Sources/GolfTracker/VideoRecorder.swift
@@ -46,10 +46,10 @@ final class VideoRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
 
     // MARK: - AVCaptureFileOutputRecordingDelegate
 
-    func fileOutput(_ output: AVCaptureFileOutput,
-                    didFinishRecordingTo outputFileURL: URL,
-                    from connections: [AVCaptureConnection],
-                    error: Error?) {
+    nonisolated func fileOutput(_ output: AVCaptureFileOutput,
+                               didFinishRecordingTo outputFileURL: URL,
+                               from connections: [AVCaptureConnection],
+                               error: Error?) {
         if let error = error {
             print("Recording error: \(error)")
         } else {


### PR DESCRIPTION
## Summary
- bridge delegate callbacks off the main actor
- add `nonisolated` delegate methods

## Testing
- `swift build` *(fails: `swift` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719d53822883229b4ee354f41c11a8