### PR TITLE
Fix data race warning for GCQuadManager

### DIFF
--- a/Sources/GolfTracker/ContentView.swift
+++ b/Sources/GolfTracker/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct ContentView: View {
     @State private var result = ""
     private let gcQuad = GCQuadManager()


### PR DESCRIPTION
## Summary
- annotate `ContentView` with `@MainActor` to ensure its members are used on the main thread

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68719e8dd0648322bda261efee541287