### PR TITLE
Fix GCQuad data race warning

### DIFF
--- a/Sources/GolfTracker/ContentView.swift
+++ b/Sources/GolfTracker/ContentView.swift
@@ -13,20 +13,26 @@ struct ContentView: View {
         Text(result.isEmpty ? "Running..." : result)
             .padding()
             .task {
-                await videoRecorder.startRecording()
-                guard let shotLocation = await locationManager.currentLocation() else {
-                    result = "Failed to get location"
-                    return
-                }
-                guard let shotData = await gcQuad.readShotData() else {
-                    result = "No shot data available"
-                    return
-                }
-                let wind = await weather.currentWind(at: shotLocation)
-                let predicted = tracker.predictLanding(shot: shotData, from: shotLocation, wind: wind)
-                await videoRecorder.stopRecording()
-                result = "Predicted landing at \(predicted.latitude), \(predicted.longitude)"
+                await performTracking()
             }
+    }
+
+    /// Runs the shot tracking workflow on the main actor to avoid
+    /// crossing actor boundaries with non-sendable properties.
+    private func performTracking() async {
+        await videoRecorder.startRecording()
+        guard let shotLocation = await locationManager.currentLocation() else {
+            result = "Failed to get location"
+            return
+        }
+        guard let shotData = await gcQuad.readShotData() else {
+            result = "No shot data available"
+            return
+        }
+        let wind = await weather.currentWind(at: shotLocation)
+        let predicted = tracker.predictLanding(shot: shotData, from: shotLocation, wind: wind)
+        await videoRecorder.stopRecording()
+        result = "Predicted landing at \(predicted.latitude), \(predicted.longitude)"
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid capturing `gcQuad` in a concurrent task
- extract tracking logic to a main actor method

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68719f909d248322bb946af25b67bdc3