### PR TITLE
Add Info.plist for iOS build

### DIFF
--- a/Sources/GolfTracker/Info.plist
+++ b/Sources/GolfTracker/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleDisplayName</key>
+    <string>GolfTracker</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleName</key>
+    <string>GolfTracker</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>NSCameraUsageDescription</key>
+    <string>Camera access is required to record your swing.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Location access is required to tag each shot.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- include a basic Info.plist file for the app

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6871a22caaa4832288cbf7ce441974aa